### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -33,6 +33,7 @@ jobs:
   pushover:
     name: pushover if failure
     if: github.ref_name == github.event.repository.default_branch && failure()
+    permissions: {}
     needs: [actionlint, codeql]
     uses: ./.github/workflows/pushover.yml
     secrets:


### PR DESCRIPTION
Potential fix for [https://github.com/masutaka/actions/security/code-scanning/3](https://github.com/masutaka/actions/security/code-scanning/3)

To fix this problem, explicitly set a `permissions` block for the `pushover` job in `.github/workflows/my_test.yml`. Since the `pushover` job likely just calls a notification workflow and doesn’t require repository write access (and we've not been given any evidence that the job requires more), assign it no permissions with `permissions: {}` (equivalent to `permissions: none`). This should be inserted right under the `name:` or after `if:`, as a sibling of other job-level fields like `needs` or `uses`. No changes are required to any other aspect of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
