### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pushover.yml
+++ b/.github/workflows/pushover.yml
@@ -8,6 +8,8 @@ on:
       PUSHOVER_USER_KEY:
         required: true
 
+permissions:
+  contents: read
 jobs:
   pushover:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/masutaka/actions/security/code-scanning/1](https://github.com/masutaka/actions/security/code-scanning/1)

To fix this problem, add a `permissions:` key at the root of the workflow file (before the `jobs:` key). This setting will apply minimal permissions (the least permissions required by this notification-only workflow) for all jobs within the workflow file, restricting the GitHub Actions GITHUB_TOKEN to only `contents: read`. You should place it after the `name:` block (if present) and before `jobs:`. No existing functionality will change, as this job doesn't require broader permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
