### PR TITLE
reusable workflow の permissions を整備する

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,9 @@ jobs:
     name: Filter Paths
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       languages: ${{ steps.format.outputs.languages }}
     steps:
@@ -93,6 +96,10 @@ jobs:
   languages:
     needs: changes
     if: ${{ needs.changes.outputs.languages != '[]' }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql_core.yml
+++ b/.github/workflows/codeql_core.yml
@@ -16,6 +16,10 @@ jobs:
     name: Perform CodeQL for ${{ inputs.language }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/create_gh_issue.yml
+++ b/.github/workflows/create_gh_issue.yml
@@ -29,6 +29,9 @@ jobs:
   create_issue:
     runs-on: ubuntu-slim
     timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v6
       - name: Create a issue

--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -17,6 +17,9 @@ jobs:
   dependency_review:
     runs-on: ubuntu-slim
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/dependency-review-action@v4

--- a/.github/workflows/my_schedule.yml
+++ b/.github/workflows/my_schedule.yml
@@ -8,7 +8,6 @@ jobs:
   codeql:
     permissions:
       actions: read
-      checks: read
       contents: read
       security-events: write
     uses: ./.github/workflows/codeql_core.yml

--- a/.github/workflows/my_test.yml
+++ b/.github/workflows/my_test.yml
@@ -14,8 +14,8 @@ jobs:
   codeql:
     permissions:
       actions: read
-      checks: read
       contents: read
+      pull-requests: read
       security-events: write
     uses: ./.github/workflows/codeql.yml
   pushover:

--- a/docs/codeql.md
+++ b/docs/codeql.md
@@ -35,49 +35,22 @@ Code Scanning のデフォルト設定を使用した場合、以下の課題が
 
 ## 使用例
 
-### 基本的な使用方法
-
 ```yml
 name: CodeQL
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   codeql:
     uses: masutaka/actions/.github/workflows/codeql.yml@main
     permissions:
       actions: read
-      checks: read
       contents: read
-      security-events: write
-```
-
-### マージキューを使用するリポジトリ
-
-マージキューを使用しているリポジトリでは、ジョブの実行ブランチが以下の命名規則に沿ったブランチになることがある。
-
-```txt
-gh-readonly-queue/{base_branch}/pr-{pr_num}-{base_branch_hash}
-```
-
-このブランチはリモートには存在しないため、codeql.yml が使用する `dorny/paths-filter` が失敗する場合がある。その際は以下のようにブランチの除外条件を追加すればよい。
-
-```yml
-name: CodeQL
-
-on:
-  push:
-    branches-ignore:
-      - gh-readonly-queue/main/pr-*
-
-jobs:
-  codeql:
-    uses: masutaka/actions/.github/workflows/codeql.yml@main
-    permissions:
-      actions: read
-      checks: read
-      contents: read
+      pull-requests: read
       security-events: write
 ```
 
@@ -86,3 +59,4 @@ jobs:
 - [Finding security vulnerabilities and errors in your code with code scanning - GitHub Docs](https://docs.github.com/code-security/code-scanning)
 - [CodeQL overview — CodeQL](https://codeql.github.com/docs/codeql-overview/)
 - https://github.com/github/codeql-action
+- https://github.com/actions/starter-workflows/blob/main/code-scanning/codeql.yml

--- a/docs/codeql_core.md
+++ b/docs/codeql_core.md
@@ -42,7 +42,6 @@ jobs:
         language: [actions, ruby]
     permissions:
       actions: read
-      checks: read
       contents: read
       security-events: write
     uses: masutaka/actions/.github/workflows/codeql_core.yml@main
@@ -55,3 +54,4 @@ jobs:
 - [Finding security vulnerabilities and errors in your code with code scanning - GitHub Docs](https://docs.github.com/code-security/code-scanning)
 - [CodeQL overview — CodeQL](https://codeql.github.com/docs/codeql-overview/)
 - https://github.com/github/codeql-action
+- https://github.com/actions/starter-workflows/blob/main/code-scanning/codeql.yml

--- a/docs/dependency_review.md
+++ b/docs/dependency_review.md
@@ -57,9 +57,6 @@ name: Dependency Review
 
 on: [pull_request]
 
-permissions:
-  contents: read
-
 jobs:
   dependency_review:
     uses: masutaka/actions/.github/workflows/dependency_review.yml@main

--- a/docs/pushover.md
+++ b/docs/pushover.md
@@ -40,8 +40,7 @@ jobs:
     if: github.ref_name == github.event.repository.default_branch && failure()
     needs: [build, test]
     uses: masutaka/actions/.github/workflows/pushover.yml@main
-    permissions:
-      contents: read
+    permissions: {}
     secrets:
       PUSHOVER_API_KEY: ${{ secrets.PUSHOVER_API_KEY }}
       PUSHOVER_USER_KEY: ${{ secrets.PUSHOVER_USER_KEY }}


### PR DESCRIPTION
closes #29

## 概要

リポジトリ内の全 reusable workflow に、呼び出し側に要求する最小権限を**ジョブレベルで明示**する。併せて、過剰な `checks: read` の削除、不足していた `pull-requests: read` の追加、docs と実装の不整合修正など、permissions 周りの整備をまとめて行う。

CodeQL の `actions/missing-workflow-permissions` への対応だけでなく、以下の目的を兼ねる。

- reusable workflow 自体を「必要権限の単一の情報源」として self-documenting にする
- 呼び出し側が広めに grant した場合のセーフティネット（intersection によるキャップ）
- 既存の `add_assignee_to_pr.yml` / `pushover.yml` のスタイルに揃える

## 変更内容

### permissions の追加

| workflow | 権限 |
| --- | --- |
| `create_gh_issue.yml` | `contents: read` + `issues: write` |
| `codeql.yml` (changes) | `contents: read` + `pull-requests: read` |
| `codeql.yml` (languages) | `actions: read` + `contents: read` + `security-events: write` |
| `codeql_core.yml` | `actions: read` + `contents: read` + `security-events: write` |
| `dependency_review.yml` | `contents: read` + `pull-requests: write` |

### `checks: read` の削除

route06/actions から引き継いでいたが、[公式 CodeQL Action README](https://github.com/github/codeql-action) や [actions/starter-workflows の CodeQL 例](https://github.com/actions/starter-workflows/blob/main/code-scanning/codeql.yml) に根拠がなく、過剰権限だったため削除。`codeql.yml`, `codeql_core.yml`, `docs/codeql.md`, `docs/codeql_core.md`, `my_test.yml`, `my_schedule.yml` から除去。

### `pull-requests: read` の追加

`codeql.yml` の `changes` ジョブで使っている `dorny/paths-filter` は、PR イベント時に GitHub REST API で変更ファイルを取得するため `pull-requests: read` が必要（[README に明記](https://github.com/dorny/paths-filter)）。宣言が欠けていたため追加。

### docs の整理

- `docs/pushover.md`: `permissions: contents: read` が workflow 実装 (`permissions: {}`) とずれていたため `{}` に修正
- `docs/codeql.md`: `on:` トリガを `push` 単独から `push: branches: [main]` + `pull_request:` の実運用形に修正
- `docs/codeql.md`: マージキュー用セクションを削除（このリポジトリの GitHub Pro プランでは merge queue が使えないため）
- `docs/codeql.md`, `docs/codeql_core.md`: 権限構成の根拠として `actions/starter-workflows` の CodeQL 例を「関連」に追加
- `docs/dependency_review.md`: `never` モード例の冗長な top-level `permissions:` を削除し、ジョブレベル宣言のみに統一

### caller 側の同期

reusable workflow の contract 変更に追随するため、このリポジトリ内の実 caller も更新。

- `my_test.yml`: codeql 呼び出しの permissions から `checks: read` を削除、`pull-requests: read` を追加
- `my_schedule.yml`: codeql (core) 呼び出しの permissions から `checks: read` を削除

## 補足: `dependency_review.yml` の条件付き権限について

`comment-summary-in-pr` 入力の値によって必要権限が変わるため、**最大権限 (`contents: read` + `pull-requests: write`) を宣言**する設計を採用した。`never` モードの caller が `pull-requests` を grant しない場合は intersection で自動的に落ちるため、過剰権限にはならない。