### PR TITLE
chore: actionlint のインストールに attestation 検証を追加する

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,9 +17,16 @@ jobs:
       - uses: actions/checkout@v7
       - name: Run actionlint
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           tarball="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           curl -fsSL -O "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${tarball}"
+          # 正規の release workflow がビルドした成果物であることを検証する
+          gh attestation verify "$tarball" \
+            --repo rhysd/actionlint \
+            --signer-workflow rhysd/actionlint/.github/workflows/release.yaml
+          # ピンした時点から中身が変わっていないことを検証する
           echo "${ACTIONLINT_CHECKSUM}  ${tarball}" | sha256sum -c -
           tar -xzf "$tarball" actionlint
           ./actionlint -color


### PR DESCRIPTION
Close #34

## 変更内容

`.github/workflows/actionlint.yml` の actionlint インストールに `gh attestation verify` を追加した。既存の `ACTIONLINT_CHECKSUM` による SHA256 検証はそのまま残している。

## なぜ両方やるのか

守る対象が違うため。

- **attestation**: バージョンを上げる瞬間を守る。「今から使おうとしている成果物は、正規の CI が作ったものか」
- **SHA256**: 固定した後を守る。「一度検証した成果物が、その後すり替わっていないか」

CI を通さずリリースに手作りバイナリを添付するケースは attestation でしか防げず、同じ tag を貼り直して再ビルドするケースは SHA256 でしか防げない。

## 確認したこと

- `gh attestation verify actionlint_1.7.12_linux_amd64.tar.gz --repo rhysd/actionlint --signer-workflow rhysd/actionlint/.github/workflows/release.yaml` が手元で exit=0
- ダウンロードした tarball の SHA256 が `ACTIONLINT_CHECKSUM` と一致
- `actionlint` によるワークフローの構文チェックが通過

`ubuntu-slim` には GitHub CLI がプリインストール済みのため、追加セットアップは不要。`permissions` は `contents: read` のまま、`env` に `GH_TOKEN: ${{ github.token }}` のみ追加した。