### PR TITLE
refactor: gh_action_lint の step 構成を整理する

### DIFF
--- a/.github/workflows/gh_action_lint.yml
+++ b/.github/workflows/gh_action_lint.yml
@@ -9,6 +9,10 @@ env:
   GHALINT_VERSION: 1.5.6
   GHALINT_CHECKSUM: 98ee0e3330de7286f470d1e89c03ff7ce70d7a5998ba0f15969c400447be579c
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   actionlint:
     runs-on: ubuntu-slim
@@ -19,8 +23,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Run actionlint
-        shell: bash
+      - name: Install actionlint
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -33,7 +36,8 @@ jobs:
           # ピンした時点から中身が変わっていないことを検証する
           echo "${ACTIONLINT_CHECKSUM}  ${tarball}" | sha256sum -c -
           tar -xzf "$tarball" actionlint
-          ./actionlint -color
+      - name: Run actionlint
+        run: ./actionlint -color
 
   ghalint:
     runs-on: ubuntu-slim
@@ -44,8 +48,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Run ghalint
-        shell: bash
+      - name: Install ghalint
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -59,4 +62,5 @@ jobs:
           # ピンした時点から中身が変わっていないことを検証する
           echo "${GHALINT_CHECKSUM}  ${tarball}" | sha256sum -c -
           tar -xzf "$tarball" ghalint
-          ./ghalint run
+      - name: Run ghalint
+        run: ./ghalint run


### PR DESCRIPTION
`gh_action_lint.yml` の step 構成を整理しました。動作は変えていません。

## インストールと実行を別 step に分けた

`GH_TOKEN` が必要なのは `gh attestation verify` だけなので、実行 step には渡さないようにしました。

なお、検証（attestation + checksum）をさらに別 step に切り出すことも検討しましたが、見送っています。検証はダウンロードと展開の間に入る必要があり、分割すると `tarball` 変数を各 step で再定義するコストが上回るためです。

## shell: bash を defaults に集約した

`run` のデフォルトは `bash -e` ですが、`shell: bash` を明示すると `bash --noprofile --norc -eo pipefail` になります。`pipefail` があることで `echo ... | sha256sum -c -` のようなパイプでも失敗を拾えるため、この指定自体は残す必要があります。

workflow の `defaults` に置くことで重複を排除しつつ、今後追加する step にも自動で効くようにしました。
