### PR TITLE
feat: 未検査だった action.yml も ghalint の検査対象にする

### DIFF
--- a/.github/workflows/gh_action_lint.yml
+++ b/.github/workflows/gh_action_lint.yml
@@ -64,3 +64,5 @@ jobs:
           tar -xzf "$tarball" ghalint
       - name: Run ghalint
         run: ./ghalint run
+      - name: Run ghalint run-action
+        run: ./ghalint run-action

--- a/docs/gh_action_lint.md
+++ b/docs/gh_action_lint.md
@@ -1,9 +1,11 @@
 # gh_action_lint
 
-`gh_action_lint` reusable workflow [`.github/workflows/gh_action_lint.yml`](../.github/workflows/gh_action_lint.yml) は、GitHub Actions のワークフローファイルを 2 つの linter で検査する。
+`gh_action_lint` reusable workflow [`.github/workflows/gh_action_lint.yml`](../.github/workflows/gh_action_lint.yml) は、GitHub Actions の設定ファイルを 2 つの linter で検査する。
 
 - [actionlint](https://github.com/rhysd/actionlint) は、構文や式、`run` のシェルスクリプトの誤りを検出する
 - [ghalint](https://github.com/suzuki-shunsuke/ghalint) は、`permissions` や secret の扱いといったセキュリティポリシーへの準拠を見る。検査内容は [Policies](https://github.com/suzuki-shunsuke/ghalint#policies) を参照
+    - `ghalint run` は `.github/workflows/*.{yml,yaml}` を検査する
+    - `ghalint run-action` は `action.{yml,yaml}` を検査する。リポジトリルート直下だけでなく、`.github/actions/foo/action.yml` のようにサブディレクトリへ切り出した composite action も対象になる
 
 それぞれ別のジョブなので、片方が失敗しても、もう片方の結果は得られる。
 


### PR DESCRIPTION
`gh_action_lint.yml` の ghalint ジョブに `ghalint run-action` を追加しました。

## 背景

`ghalint run` が見るのは `.github/workflows/*.{yml,yaml}` だけなので、composite action の `action.yml` は完全に未検査でした。`action_shell_is_required`（`run` に `shell` が必須）のように `run-action` でしか効かないポリシーもあります。

現状で違反しているリポジトリは無いため、回帰防止としての追加です。

## `action.yml` の有無で分岐させなかった理由

`action.yml` を持たないリポジトリで無駄な処理をしないよう、ガードを入れることも検討しましたが見送りました。

- ghalint が探すのは `action.{yml,yaml}` をリポジトリルートから 3 階層下までなので、`[ -f action.yml ]` のような素朴なガードだと `.github/actions/foo/action.yml` を取りこぼす。composite action を切り出す場所として `.github/actions/` は定石なので、踏む可能性は低くない
- 正確にガードするには ghalint と同じ探索を再実装することになり、ガードのほうが守る対象より長くなる
- そもそも action ファイルが 1 つも無いリポジトリでは、ghalint 側が走査して即 exit 0 になる。手元の計測では `user 0.00s + sys 0.01s` で、ほぼプロセス起動のオーバーヘッドのみ

## `Run ghalint` とは別 step にした

Actions の UI で `run` と `run-action` のどちらが失敗したかが分かるようにするためです。#39 でインストールと実行を別 step に分けた方針にも揃えています。
